### PR TITLE
Fix intra-doc links

### DIFF
--- a/src/buffered/ordered.rs
+++ b/src/buffered/ordered.rs
@@ -8,7 +8,7 @@ use futures_core::Stream;
 use pin_project_lite::pin_project;
 
 pin_project! {
-    /// Stream for the [`buffered_ordered`](BufferedStreamExt::buffered_ordered) method.
+    /// Stream for the [`buffered_ordered`](crate::BufferedStreamExt::buffered_ordered) method.
     #[must_use = "streams do nothing unless polled"]
     pub struct BufferedOrdered<St>
     where

--- a/src/buffered/unordered.rs
+++ b/src/buffered/unordered.rs
@@ -9,7 +9,7 @@ use pin_project_lite::pin_project;
 use crate::FuturesUnorderedBounded;
 
 pin_project!(
-    /// Stream for the [`buffered_unordered`](BufferedStreamExt::buffered_unordered)
+    /// Stream for the [`buffered_unordered`](crate::BufferedStreamExt::buffered_unordered)
     /// method.
     ///
     /// # Examples


### PR DESCRIPTION
From the rust book on valid links:

> You can refer to anything in scope, and use paths, including Self, self, super, and crate.

There were a couple of things not in scope so they needed a full path for the link to work. You can see this in the `buffered_unordered` link here https://docs.rs/futures-buffered/latest/futures_buffered/struct.BufferUnordered.html