### PR TITLE
feat: add is_empty and len methods to MergeUnbounded

### DIFF
--- a/src/merge_unbounded.rs
+++ b/src/merge_unbounded.rs
@@ -90,11 +90,7 @@ impl<S> MergeUnbounded<S> {
 
     /// Returns `true` if there are no streams in the set.
     pub fn is_empty(&self) -> bool {
-        if self.groups.is_empty() {
-            true
-        } else {
-            self.groups.iter().all(|g| g.streams.is_empty())
-        }
+        self.groups.iter().all(|g| g.streams.is_empty())
     }
 
     /// Returns the number of streams currently in the set.


### PR DESCRIPTION
Adds `MergeUnbounded::is_empty` and `MergeUnbounded::len`.
The former is quite useful when using in a `tokio::select!` loop to disable the branch if the stream set is empty.